### PR TITLE
env: install pydensecrf from github

### DIFF
--- a/environment_dev.yaml
+++ b/environment_dev.yaml
@@ -1,9 +1,9 @@
-name: doodler-dev
+name: doodler-dev-test
 channels:
   - conda-forge
   - defaults
 dependencies:
- - python
+ - python=3.7
  - CairoSVG
  - matplotlib
  - scipy
@@ -11,7 +11,6 @@ dependencies:
  - scikit-image
  - Pillow
  - scikit-learn
- - pydensecrf
  - cairo
  - tqdm
  - psutil
@@ -21,3 +20,6 @@ dependencies:
  - flake8
  - pytest
  - pytest-cov
+ - pip
+ - pip:
+   - git+https://github.com/li-plus/pydensecrf.git@0d53acbcf5123d4c88040fe68fbb9805fc5b2fb9


### PR DESCRIPTION
pydensecrf has no conda version available after 3.6. It also has no recent version on pip. So we install it directly from its Github repo, from the latest commit at the time of this PR: https://github.com/lucasb-eyer/pydensecrf/commit/0d53acbcf5123d4c88040fe68fbb9805fc5b2fb9

This allows to update the Python version of the environment to 3.7, which in turns allows to use the latest versions of Panel :)