### PR TITLE
Underline active button and set vertical padding

### DIFF
--- a/doodler/components.py
+++ b/doodler/components.py
@@ -39,7 +39,7 @@ class Toggle(pn.reactive.ReactiveHTML):
     color = param.String(doc='Color of the border in hex format')
 
     _template = """
-    <button id="button" style="border-color:{{ color }};border-width:4px;border-radius:5%;padding-inline:10px;font-weight:{{ 'bold' if active else 'normal' }}" onclick="${_update}">
+    <button id="button" style="text-decoration: {{ 'underline' if active else 'normal' }};border-color:{{ color }};border-width:4px;border-radius:5%;padding:10px;font-weight:{{ 'bold' if active else 'normal' }}" onclick="${_update}">
         {{ klass }}
     </button>"""
 
@@ -47,8 +47,10 @@ class Toggle(pn.reactive.ReactiveHTML):
         'active': """
         if (data.active) {
             button.style.fontWeight = "bold"
+            button.style.textDecoration = "underline"
         } else {
             button.style.fontWeight = "normal"
+            button.style.textDecoration = null
         }
         """
     }


### PR DESCRIPTION
Partially addresses https://github.com/pyviz-topics/holodoodler/issues/26, the buttons are now bigger and the selected class is underlined.

<img width="351" alt="image" src="https://user-images.githubusercontent.com/35924738/170254641-175e0e9f-c8c1-46ee-954b-bd2046cbceca.png">
